### PR TITLE
fix: handle Vercel auto-parsed JSON body

### DIFF
--- a/src/webhook/validator.ts
+++ b/src/webhook/validator.ts
@@ -18,25 +18,41 @@ export function validateMethod(method: string | undefined): boolean {
 }
 
 /**
- * Parses JSON string and returns result or error
- * @param body - JSON string to parse
+ * Parses JSON string or returns object if already parsed
+ * @param body - JSON string to parse or already parsed object
  * @returns Object with parsed data or error
  */
 export function parseJSON(
-  body: string | undefined
+  body: string | unknown | undefined
 ): { success: true; data: unknown } | { success: false; error: string } {
-  if (body === undefined || body === null || body === '') {
+  if (body === undefined || body === null) {
     return { success: false, error: 'Request body is required' };
   }
 
-  try {
-    const data: unknown = JSON.parse(body);
-    return { success: true, data };
-  } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : 'Invalid JSON format';
-    return { success: false, error: errorMessage };
+  // If body is already an object (Vercel auto-parsed JSON), return it directly
+  if (typeof body === 'object') {
+    return { success: true, data: body };
   }
+
+  // If body is empty string, return error
+  if (body === '') {
+    return { success: false, error: 'Request body is required' };
+  }
+
+  // If body is a string, parse it
+  if (typeof body === 'string') {
+    try {
+      const data: unknown = JSON.parse(body);
+      return { success: true, data };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Invalid JSON format';
+      return { success: false, error: errorMessage };
+    }
+  }
+
+  // Fallback for unexpected types
+  return { success: false, error: 'Request body must be JSON' };
 }
 
 /**

--- a/tests/webhook/validator.test.ts
+++ b/tests/webhook/validator.test.ts
@@ -143,6 +143,35 @@ describe('parseJSON', () => {
       expect(result.data).toEqual(payload);
     }
   });
+
+  it('should return object directly when body is already parsed (Vercel behavior)', () => {
+    const payload = {
+      notificationType: 'Message',
+      type: 'CustomerCreated',
+      resource: { typeId: 'customer', id: 'test-id' },
+      projectKey: 'test-project',
+      id: 'notification-id',
+      version: 1,
+      sequenceNumber: 1,
+      resourceVersion: 1,
+      createdAt: '2024-01-01T00:00:00.000Z',
+      lastModifiedAt: '2024-01-01T00:00:00.000Z',
+    };
+    const result = parseJSON(payload);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(payload);
+    }
+  });
+
+  it('should return error for null body', () => {
+    const result = parseJSON(null);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe('Request body is required');
+    }
+  });
 });
 
 describe('validatePayload', () => {


### PR DESCRIPTION
Vercel automatically parses JSON bodies when Content-Type is application/json, so req.body is already an object, not a string. Update parseJSON to handle both cases:
- If body is already an object (Vercel parsed), return it directly
- If body is a string, parse it as before

Fixes error: '[object Object] is not valid JSON'

Adds test coverage for Vercel's auto-parsing behavior.